### PR TITLE
feat: api analytics filter url (start with /api)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -150,7 +150,7 @@ Promise.all([
 
   if(context.env.API_ANALYTICS_KEY) {
     context.analyticsAgent = analytics({
-      apiKey: context.env.API_ANALYTICS_KEY,
+      prefix: '/api',
       uuidResolver: function agentUuidResolver(req) {
         return req.user && req.user._id ? req.user._id.toString() : null;
       },


### PR DESCRIPTION
Monitore uniquement les url qui commence par /api
(je supprime l'apiKey au passage présent dans le fichier de config)
